### PR TITLE
#264 - Decoder CUDA Issue Fix

### DIFF
--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -553,7 +553,7 @@ def decompress(model_path, input_path, model_name, config):
     model.eval()
 
     # Load the data, convert to tensor and batch it to avoid memory leaks
-    data_tensor = torch.from_numpy(data)
+    data_tensor = torch.from_numpy(data).to(device)
     data_dl = DataLoader(
         data_tensor,
         batch_size=bs,
@@ -580,7 +580,7 @@ def decompress(model_path, input_path, model_name, config):
         decompressed = decompressed.view(
             len(decompressed), number_of_columns, number_of_columns
         )
-    decompressed = decompressed.detach().numpy()
+    decompressed = decompressed.detach().cpu().numpy()
 
     return decompressed, names, normalization_features
 


### PR DESCRIPTION
Issue Resolution - https://github.com/baler-collaboration/baler/issues/264

First, we move data to the device so that while running CUDA the model and data both are in GPUs. 
Since we convert tensor to numpy, we have to load the decoded model output to CPU memory first. 

Tested this with CPU and CUDA and seems to be working.