### PR TITLE
Issues/270 - 3D Convolution Nets for CFD Animation Reconstruction

### DIFF
--- a/baler/baler.py
+++ b/baler/baler.py
@@ -124,6 +124,11 @@ def perform_training(output_path, config, verbose: bool):
     model = model_object(n_features=number_of_columns, z_dim=config.latent_space_size)
     model.to(device)
 
+    if config.model_name == "Conv_AE_3D" and hasattr(
+        config, "compress_to_latent_space"
+    ):
+        model.set_compress_to_latent_space(config.compress_to_latent_space)
+
     if verbose:
         print(f"Model architecture:\n{model}")
 

--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -476,7 +476,11 @@ def compress(model_path, config):
     # elif config.data_dimension == 1:
     #     data_tensor = torch.from_numpy(data).to(device)
     if config.data_dimension == 2:
-        if config.model_type == "convolutional":
+        if config.model_type == "convolutional" and config.model_name == "Conv_AE_3D":
+            data_tensor = torch.tensor(data, dtype=torch.float32).view(
+                1, 1, data.shape[0], data.shape[1], data.shape[2]
+            )
+        elif config.model_type == "convolutional":
             data_tensor = torch.tensor(data, dtype=torch.float32).view(
                 data.shape[0], 1, data.shape[1], data.shape[2]
             )

--- a/baler/modules/plotting.py
+++ b/baler/modules/plotting.py
@@ -267,7 +267,9 @@ def plot_2D(project_path, config):
 
     print("=== Plotting ===")
     for ind in trange(num_tiles):
-        if config.model_type == "convolutional":
+        if config.model_type == "convolutional" and config.model_name == "Conv_AE_3D":
+            tile_data_decompressed = data_decompressed[0][0][ind] * 0.04 * 1000
+        elif config.model_type == "convolutional":
             tile_data_decompressed = data_decompressed[ind][0] * 0.04 * 1000
         elif config.model_type == "dense":
             tile_data_decompressed = data_decompressed[ind] * 0.04 * 1000

--- a/baler/modules/training.py
+++ b/baler/modules/training.py
@@ -179,6 +179,13 @@ def train(model, variables, train_data, test_data, project_path, config):
             valid_ds = torch.tensor(test_data, dtype=torch.float32, device=device).view(
                 train_data.shape[0], train_data.shape[1] * train_data.shape[2]
             )
+        elif config.model_type == "convolutional" and config.model_name == "Conv_AE_3D":
+            train_ds = torch.tensor(
+                train_data, dtype=torch.float32, device=device
+            ).view(1, 1, train_data.shape[0], train_data.shape[1], train_data.shape[2])
+            valid_ds = torch.tensor(test_data, dtype=torch.float32, device=device).view(
+                1, 1, train_data.shape[0], train_data.shape[1], train_data.shape[2]
+            )
         elif config.model_type == "convolutional":
             train_ds = torch.tensor(
                 train_data, dtype=torch.float32, device=device

--- a/docs/setup/python_setup.md
+++ b/docs/setup/python_setup.md
@@ -31,27 +31,27 @@ Here we provide some instructions for our working examples.
 #### Training ####
 To train the autoencoder to compress your data, you run the following command. The config file `./workspaces/CFD_workspace/CFD_project_v1/config/CFD_project_v1_config.py`. This details the path of the data, the number of epochs, and all the other training parameters.
 ```console
-poetry run python baler --project CFD_workspace CFD_project_animation --mode train
+poetry run python -m baler --project CFD_workspace CFD_project_animation --mode train
 ```
 
 #### Compressing ####
 To use the derived model for compression, you can now choose ``--mode compress``, which can be run as
 ```console
-poetry run python baler --project CFD_workspace CFD_project_animation --mode compress
+poetry run python -m baler --project CFD_workspace CFD_project_animation --mode compress
 ```
 This will output a compressed file called "compressed.pickle", and this is the latent space representation of the input dataset. It will also output cleandata_pre_comp.pickle which is just the exact data being compressed.
 
 #### Decompressing ####
 To decompress the compressed file, we choose --mode decompress and run:
 ```console
-poetry run python baler --project CFD_workspace CFD_project_animation --mode decompress
+poetry run python -m baler --project CFD_workspace CFD_project_animation --mode decompress
 ```
 
 #### Plotting ####
 To plot the difference of your variables before compression and after decompression, we can use the following command to generate a .pdf document under ``./workspaces/firstWorkspace/firstProject/output/plotting/comparison.pdf``
 
 ```console
-poetry run python baler --project CFD_workspace CFD_project_animation --mode plot
+poetry run python -m baler --project CFD_workspace CFD_project_animation --mode plot
 ```
 
 ### High Energy Physics Example ###
@@ -60,5 +60,5 @@ To run our High Energy Physics using CMS data (DOI:10.7483/OPENDATA.CMS.KL8H.HFV
 ## New project ##
 To create the folder structure and a skeleton config for your own project:
 ```console
-poetry run python baler --project firstWorkspace firstProject --mode newProject
+poetry run python -m baler --project firstWorkspace firstProject --mode newProject
 ```

--- a/workspaces/CFD_workspace/CFD_project_animation/config/CFD_project_animation_config.py
+++ b/workspaces/CFD_workspace/CFD_project_animation/config/CFD_project_animation_config.py
@@ -25,6 +25,7 @@ def set_config(c):
     c.intermittent_saving_patience = 100
     c.activation_extraction = False
     c.deterministic_algorithm = False
+    c.compress_to_latent_space = False
 
 
 # def set_config(c):


### PR DESCRIPTION
Adding a 3D Conv Net with a feature "compress to latent space".
When above feature is set to False, the Conv Net will not force to compress the model to latent space allowing it to run on low memory machines. Plots look good and are attached.
 
With HPC, We should set to True and evaluate the model compression success.

Updating Documentation to run Baler.

[Uploading plotting.zip…]()
