### PR TITLE
Added -m flag while training baler. Fixes Import Error

### DIFF
--- a/docs/setup/python_setup.md
+++ b/docs/setup/python_setup.md
@@ -34,7 +34,7 @@ Here we provide some instructions for our working examples.
 #### Training ####
 To train the autoencoder to compress your data, you run the following command. The config file `./workspaces/CFD_workspace/CFD_project_v1/config/CFD_project_v1_config.py`. This details the path of the data, the number of epochs, and all the other training parameters.
 ```console
-poetry run python baler --project CFD_workspace CFD_project_animation --mode train
+poetry run python -m baler --project CFD_workspace CFD_project_animation --mode train
 ```
 
 #### Compressing ####


### PR DESCRIPTION
@exook 

Issue
- The command for training baler is presently `poetry run python baler --project CFD_workspace CFD_project_animation --mode train ` 
-  [Relative Imports Error](https://stackoverflow.com/questions/16981921/relative-imports-in-python-3) is thrown while running this command

Fix
- Using the `-m` flag fixes the issue.  
- `poetry run python -m baler --project CFD_workspace CFD_project_animation --mode train`

Screenshot of the error taken on my Linux machine
![Screenshot from 2023-07-05 11-19-01](https://github.com/baler-collaboration/baler/assets/75798265/bd3e322c-c1eb-43ff-8ea1-79eecf5eb544)


Screenshot of the error taken on my M1 MacBook Air
![Screenshot 2023-07-05 at 11 41 34 AM](https://github.com/baler-collaboration/baler/assets/75798265/5080d7ac-fac6-4fc5-8dcb-0f107190e272)
