### PR TITLE
Mark optional dependencies as optional in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,15 @@ torch = ">=2.0.0, !=2.0.1"
 tqdm = "^4.64.1"
 matplotlib = "^3.6.2"
 scikit-learn = "^1.2.0"
-hls4ml = "^0.7.1"
-tensorflow = "^2.12.0"
+hls4ml = { version = "^0.7.1", optional = true }
+tensorflow = { version = "^2.12.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"
 black = "^23.1.0"
+
+[tool.poetry.extras]
+hls4ml = [ "hls4ml", "tensorflow" ]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
With this change baler-1.1.0.dist-info/METADATA contains:

Provides-Extra: hls4ml
Requires-Dist: hls4ml (>=0.7.1,<0.8.0) ; extra == "hls4ml"
Requires-Dist: matplotlib (>=3.6.2,<4.0.0)
Requires-Dist: scikit-learn (>=1.2.0,<2.0.0)
Requires-Dist: tensorflow (>=2.12.0,<3.0.0) ; extra == "hls4ml"
Requires-Dist: torch (>=2.0.0,!=2.0.1)
Requires-Dist: tqdm (>=4.64.1,<5.0.0)
