### PR TITLE
Minor fixes

### DIFF
--- a/baler/__init__.py
+++ b/baler/__init__.py
@@ -1,8 +1,1 @@
-from .baler import (
-    perform_compression,
-    perform_decompression,
-    perform_diagnostics,
-    perform_plotting,
-    perform_training,
-    print_info,
-)
+from .baler import *

--- a/baler/baler.py
+++ b/baler/baler.py
@@ -21,6 +21,15 @@ import numpy as np
 from .modules import helper
 import gzip
 
+__all__ = (
+    "perform_compression",
+    "perform_decompression",
+    "perform_diagnostics",
+    "perform_plotting",
+    "perform_training",
+    "print_info",
+)
+
 
 def main():
     """Calls different functions depending on argument parsed in command line.

--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -39,7 +39,7 @@ def get_arguments():
     projects directory where outputs go.
     """
     parser = argparse.ArgumentParser(
-        prog="baler.py",
+        prog="baler",
         description=(
             "Baler is a machine learning based compression tool for big data.\n\n"
             "Baler has three running modes:\n\n"

--- a/docs/setup/python_setup.md
+++ b/docs/setup/python_setup.md
@@ -21,8 +21,8 @@ poetry install
 4. Try the installation with `poetry run baler`, this should give the following output:
 
 ```console
-usage: baler.py [-h] --mode MODE --project WORKSPACE PROJECT [--verbose]
-baler.py: error: the following arguments are required: --mode, --project
+usage: baler [-h] --mode MODE --project WORKSPACE PROJECT [--verbose]
+baler: error: the following arguments are required: --mode, --project
 ```
 
 ## Working Example with Python


### PR DESCRIPTION
[Declare __all__ in baler.py instead of listing imports in __init__.py](https://github.com/baler-collaboration/baler/commit/fb94657a555e4c081963f3932d7a6e364ca6a195)

End result is the same, but keeps the list of imported/exported names in the same file as their definitions, which is less confusing.

[Use "baler" instead of "baler.py" as the progname in the help text.](https://github.com/baler-collaboration/baler/commit/f2c23235559b825e50b592747a8a97d3b76775b6)

The program is the wrapper script generated from the entrypoint definition (baler), not the python module (baler.py).