### PR TITLE
Update CFD_project_animation_config.py

### DIFF
--- a/workspaces/CFD_workspace/CFD_project_animation/config/CFD_project_animation_config.py
+++ b/workspaces/CFD_workspace/CFD_project_animation/config/CFD_project_animation_config.py
@@ -28,7 +28,7 @@ def set_config(c):
     c.compress_to_latent_space = False
     c.save_error_bounded_deltas = False
     c.error_bounded_requirement = 1
-    c.convert_to_blocks = [5, 5, 5]
+    c.convert_to_blocks = [1, 50, 50]
 
 
 # def set_config(c):


### PR DESCRIPTION
When using dimensions [5, 5, 5] (smaller than actual images) it means the reproduction has some "gridlines" on it.  By changing blocking dimensions to be by size of image (50x50) we can get better reconstructions.