### PR TITLE
tests no longer remove workspaces directory

### DIFF
--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -110,7 +110,10 @@ def get_arguments():
 
 
 def create_new_project(
-    workspace_name: str, project_name: str, verbose: bool = False
+    workspace_name: str,
+    project_name: str,
+    verbose: bool = False,
+    base_path: str = "workspaces",
 ) -> None:
     """Creates a new project directory output subdirectories and config files within a workspace.
 
@@ -119,8 +122,6 @@ def create_new_project(
         project_name (str): Creates a project (dir) for storing configs and outputs with this name.
         verbose (bool, optional): Whether to print out the progress. Defaults to False.
     """
-
-    base_path = "workspaces"
 
     # Create full project path
     workspace_path = os.path.join(base_path, workspace_name)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -21,7 +21,7 @@ from baler.modules import helper
 def test_create_new_project():
     workspace_name = "test_workspace"
     project_name = "test_project"
-    base_path = os.path.join("workspaces")
+    base_path = os.path.join("test_workspaces")
     workspace_path = os.path.join(base_path, workspace_name)
     project_path = os.path.join(workspace_path, project_name)
 
@@ -29,7 +29,7 @@ def test_create_new_project():
     if os.path.exists(workspace_path):
         shutil.rmtree(workspace_path)
 
-    helper.create_new_project(workspace_name, project_name)
+    helper.create_new_project(workspace_name, project_name, base_path=base_path)
 
     # Verify that the project was created successfully
     assert os.path.exists(workspace_path)


### PR DESCRIPTION
Running tests locally would delete the `workspaces` directory along with relevant files. Now isolates tests to specific folder.