### PR TITLE
350 add pj model to baler

### DIFF
--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -639,6 +639,7 @@ def decompress(
     if config.model_type == "convolutional":
         final_layer_details = np.load(
             os.path.join(output_path, "training", "final_layer.npy"),
+            allow_pickle=True
         )
 
     if config.save_error_bounded_deltas:

--- a/baler/modules/helper.py
+++ b/baler/modules/helper.py
@@ -638,8 +638,7 @@ def decompress(
 
     if config.model_type == "convolutional":
         final_layer_details = np.load(
-            os.path.join(output_path, "training", "final_layer.npy"),
-            allow_pickle=True
+            os.path.join(output_path, "training", "final_layer.npy"), allow_pickle=True
         )
 
     if config.save_error_bounded_deltas:

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -665,88 +665,9 @@ class Conv_AE_GDN(nn.Module):
         self.conv_op_shape = conv_op_shape
 
 
-
 class PJ_Conv_AE(nn.Module):
     def __init__(self, n_features ,z_dim=10, *args, **kwargs):
         super(PJ_Conv_AE, self).__init__(*args, **kwargs)
-
-        self.q_z_mid_dim = 800
-        self.q_z_conv_output_dim = 2450 #was 2450
-        self.conv_op_shape = None
-
-        # Encoder
-
-        # Conv Layers
-        self.q_z_conv = nn.Sequential(
-            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='valid',),
-            nn.LeakyReLU(),
-            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='valid'),
-            nn.LeakyReLU(),
-        )
-        # Flatten
-        self.flatten = nn.Flatten(start_dim=1)
-
-        # Linear layers
-        self.q_z_lin = nn.Sequential(
-            nn.Linear(self.q_z_conv_output_dim, self.q_z_mid_dim),
-            nn.LeakyReLU(),
-            nn.Linear(self.q_z_mid_dim, z_dim),
-        )
-
-        # Decoder
-
-        # Linear layers
-        self.p_x_lin = nn.Sequential(
-            nn.Linear(z_dim, self.q_z_mid_dim),
-            nn.LeakyReLU(),
-            nn.Linear(self.q_z_mid_dim, self.q_z_conv_output_dim),
-            nn.LeakyReLU()
-        )
-        # Conv Layers
-        self.p_x_conv = nn.Sequential(
-            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='valid'),
-            nn.LeakyReLU(),
-            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='valid'),
-            nn.LeakyReLU(),
-        )
-
-    def encode(self, x):
-        # Conv
-        out = self.q_z_conv(x)
-        self.conv_op_shape = out.shape
-        print(out.shape[1],out.shape[2],out.shape[3])
-        self.q_z_output_dim = out.shape[1] * out.shape[2] * out.shape[3] # should be [7,7,50] for MNIST
-        
-        # Flatten
-        out = self.flatten(out)
-        print(out.shape)
-        # Dense
-        out = self.q_z_lin(out)
-        return out
-
-    def decode(self, z):
-        # Dense
-        out = self.p_x_lin(z)
-        # Unflatten
-        out = out.view(
-            self.conv_op_shape[0],
-            self.conv_op_shape[1],
-            self.conv_op_shape[2],
-            self.conv_op_shape[3],
-        )
-        # Conv transpose
-        out = self.p_x_conv(out)
-        return out
-
-    def forward(self, x):
-        z = self.encode(x)
-        out = self.decode(z)
-        return out
-
-
-class PJ_2(nn.Module):
-    def __init__(self, n_features ,z_dim=10, *args, **kwargs):
-        super(PJ_2, self).__init__(*args, **kwargs)
 
         # Encoder
         self.encoder = nn.Sequential(

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -663,3 +663,80 @@ class Conv_AE_GDN(nn.Module):
 
     def set_final_layer_dims(self, conv_op_shape):
         self.conv_op_shape = conv_op_shape
+
+
+
+class PJ_Conv_AE(nn.Module):
+    def __init__(self, z_dim=10, *args, **kwargs):
+        super(Conv_AE, self).__init__(*args, **kwargs)
+
+        self.q_z_mid_dim = 500
+        self.q_z_conv_output_dim = 2450
+        self.conv_op_shape = None
+
+        # Encoder
+
+        # Conv Layers
+        self.q_z_conv = nn.Sequential(
+            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='same'),
+            nn.LeakyReLU(),
+            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='same'),
+            nn.LeakyReLU(),
+        )
+        # Flatten
+        self.flatten = nn.Flatten(start_dim=1)
+
+        # Linear layers
+        self.q_z_lin = nn.Sequential(
+            nn.Linear(self.q_z_conv_output_dim, self.q_z_mid_dim),
+            nn.LeakyReLU(),
+            nn.Linear(self.q_z_mid_dim, z_dim),
+        )
+
+        # Decoder
+
+        # Linear layers
+        self.p_x_lin = nn.Sequential(
+            nn.Linear(z_dim, self.q_z_mid_dim),
+            nn.LeakyReLU(),
+            nn.Linear(self.q_z_mid_dim, self.q_z_conv_output_dim),
+            nn.LeakyReLU()
+        )
+        # Conv Layers
+        self.p_x_conv = nn.Sequential(
+            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='same'),
+            nn.LeakyReLU(),
+            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='same'),
+            nn.LeakyReLU(),
+        )
+
+    def encode(self, x):
+        # Conv
+        out = self.q_z_conv(x)
+        self.conv_op_shape = out.shape
+        self.q_z_output_dim = out.shape[1] * out.shape[2] * out.shape[3] # should be [7,7,50] for MNIST
+
+        # Flatten
+        out = self.flatten(out)
+        # Dense
+        out = self.q_z_lin(out)
+        return out
+
+    def decode(self, z):
+        # Dense
+        out = self.p_x_lin(z)
+        # Unflatten
+        out = out.view(
+            self.conv_op_shape[0],
+            self.conv_op_shape[1],
+            self.conv_op_shape[2],
+            self.conv_op_shape[3],
+        )
+        # Conv transpose
+        out = self.p_x_conv(out)
+        return out
+
+    def forward(self, x):
+        z = self.encode(x)
+        out = self.decode(z)
+        return out

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -678,9 +678,9 @@ class PJ_Conv_AE(nn.Module):
 
         # Conv Layers
         self.q_z_conv = nn.Sequential(
-            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='valid'),
+            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='same'),
             nn.LeakyReLU(),
-            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='valid'),
+            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='same'),
             nn.LeakyReLU(),
         )
         # Flatten
@@ -704,9 +704,9 @@ class PJ_Conv_AE(nn.Module):
         )
         # Conv Layers
         self.p_x_conv = nn.Sequential(
-            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='valid'),
+            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='same'),
             nn.LeakyReLU(),
-            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='valid'),
+            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='same'),
             nn.LeakyReLU(),
         )
 

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -667,8 +667,8 @@ class Conv_AE_GDN(nn.Module):
 
 
 class PJ_Conv_AE(nn.Module):
-    def __init__(self, z_dim=10, *args, **kwargs):
-        super(Conv_AE, self).__init__(*args, **kwargs)
+    def __init__(self, n_features ,z_dim=10, *args, **kwargs):
+        super(PJ_Conv_AE, self).__init__(*args, **kwargs)
 
         self.q_z_mid_dim = 500
         self.q_z_conv_output_dim = 2450
@@ -678,9 +678,9 @@ class PJ_Conv_AE(nn.Module):
 
         # Conv Layers
         self.q_z_conv = nn.Sequential(
-            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='same'),
+            nn.Conv2d(1, 20, kernel_size=(5), stride=(2), padding='valid'),
             nn.LeakyReLU(),
-            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='same'),
+            nn.Conv2d(20, 50, kernel_size=(5), stride=(2), padding='valid'),
             nn.LeakyReLU(),
         )
         # Flatten
@@ -704,9 +704,9 @@ class PJ_Conv_AE(nn.Module):
         )
         # Conv Layers
         self.p_x_conv = nn.Sequential(
-            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='same'),
+            nn.ConvTranspose2d(50, 20, kernel_size=(5), stride=(2), padding='valid'),
             nn.LeakyReLU(),
-            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='same'),
+            nn.ConvTranspose2d(20, 1, kernel_size=(5), stride=(2), padding='valid'),
             nn.LeakyReLU(),
         )
 

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -666,17 +666,19 @@ class Conv_AE_GDN(nn.Module):
 
 
 class PJ_Conv_AE(nn.Module):
-    def __init__(self, n_features ,z_dim=10, *args, **kwargs):
+    def __init__(self, n_features, z_dim=10, *args, **kwargs):
         super(PJ_Conv_AE, self).__init__(*args, **kwargs)
 
         # Encoder
         self.encoder = nn.Sequential(
-            nn.Conv2d(1, 20, kernel_size=5, stride=2, padding=2),  # Adjust input channels to 1 for grayscale images
+            nn.Conv2d(
+                1, 20, kernel_size=5, stride=2, padding=2
+            ),  # Adjust input channels to 1 for grayscale images
             nn.LeakyReLU(0.2),
             nn.Conv2d(20, 50, kernel_size=5, stride=2, padding=2),
             nn.Flatten(),
             nn.Linear(50 * 7 * 7, 500),  # Adjust input size based on your data
-            nn.Linear(500, z_dim)
+            nn.Linear(500, z_dim),
         )
 
         # Decoder
@@ -685,25 +687,28 @@ class PJ_Conv_AE(nn.Module):
             nn.LeakyReLU(0.2),
             nn.Linear(500, 2450),
             nn.Unflatten(1, (50, 7, 7)),
-            nn.ConvTranspose2d(50, 20, kernel_size=5, stride=2, padding=2, output_padding=1),
-            nn.ConvTranspose2d(20, 1, kernel_size=5, stride=2, padding=2, output_padding=1),
-            nn.LeakyReLU(0.2)
+            nn.ConvTranspose2d(
+                50, 20, kernel_size=5, stride=2, padding=2, output_padding=1
+            ),
+            nn.ConvTranspose2d(
+                20, 1, kernel_size=5, stride=2, padding=2, output_padding=1
+            ),
+            nn.LeakyReLU(0.2),
         )
 
-    def encode(self,x):
+    def encode(self, x):
         return self.encoder(x)
 
-    def decode(self,z):
+    def decode(self, z):
         return self.decoder(z)
 
     def forward(self, x):
         z = self.encode(x)
         out = self.decode(z)
         return out
-    
+
     def get_final_layer_dims(self):
         return list(self.decoder.children())[-1]
-
 
     def set_final_layer_dims(self, conv_op_shape):
         self.conv_op_shape = conv_op_shape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 baler = "baler.baler:main"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.11"
+python = ">=3.8, <3.11.10"
 torch = ">=2.0.0, !=2.0.1"
 tqdm = "^4.64.1"
 matplotlib = "^3.6.2"


### PR DESCRIPTION
PJ's model was altered and added to `models.py`. This is an implementation of TensorFlows data compression notebook model, and it has been tested on the MNIST dataset. Below is an example figure of the results from online compression, where training has been done on 59980 images and compression/decompression on the 20 the network hasn't seen before. 

Some other files have been changed to update python dependencies and error which followed.

(left is Original and right is Reconstructed)
![conv_mnist](https://github.com/baler-collaboration/baler/assets/74319950/55536588-7afb-4e4d-9513-1d4664554cdd)
