### PR TITLE
367 re write pj model as fpga friendly

### DIFF
--- a/baler/modules/data_processing.py
+++ b/baler/modules/data_processing.py
@@ -57,7 +57,7 @@ def encoder_saver(model, model_path: str) -> None:
     Returns:
         None: Saved encoder state dictionary as `.pt` file.
     """
-    torch.save(model.encoder.state_dict(), model_path)
+    model.save_encoder(model_path)
 
 
 def decoder_saver(model, model_path: str) -> None:
@@ -70,7 +70,7 @@ def decoder_saver(model, model_path: str) -> None:
     Returns:
         None: Saved decoder state dictionary as `.pt` file.
     """
-    torch.save(model.decoder.state_dict(), model_path)
+    model.save_decoder(model_path)
 
 
 def initialise_model(model_name: str):

--- a/baler/modules/data_processing.py
+++ b/baler/modules/data_processing.py
@@ -57,7 +57,9 @@ def encoder_saver(model, model_path: str) -> None:
     Returns:
         None: Saved encoder state dictionary as `.pt` file.
     """
-    model.save_encoder(model_path)
+    if hasattr(model.encoder,'state_dict'):
+        torch.save(model.encoder.state_dict(),model_path)
+    else: model.save_encoder(model_path)
 
 
 def decoder_saver(model, model_path: str) -> None:
@@ -70,7 +72,9 @@ def decoder_saver(model, model_path: str) -> None:
     Returns:
         None: Saved decoder state dictionary as `.pt` file.
     """
-    model.save_decoder(model_path)
+    if hasattr(model.decoder,'state_dict'):
+        torch.save(model.decoder.state_dict(),model_path)
+    else: model.save_decoder(model_path)
 
 
 def initialise_model(model_name: str):

--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -714,52 +714,69 @@ class PJ_Conv_AE(nn.Module):
         self.conv_op_shape = conv_op_shape
 
 class PJ_Conv_AE_FPGA(nn.Module):
-    def __init__(self, n_features, z_dim, *args, **kwargs):
+    def __init__(self, n_features, z_dim=10, *args, **kwargs):
         super(PJ_Conv_AE_FPGA, self).__init__(*args, **kwargs)
 
-        # Encoder
-        self.en1 = nn.Conv2d(1,20,kernel_size=5,stride=2,padding=2, dtype=torch.float32)
+        
+        # Encoder layers
+        self.en1 = nn.Conv2d(1, 20, kernel_size=5, stride=2, padding=2)
         self.en_act1 = nn.ReLU()
-        self.en2 = nn.Conv2d(20, 50, kernel_size=5, stride=2, padding=2, dtype=torch.float32)
-        self.en_flat = nn.Flatten()
-        self.en3 = nn.Linear(50 * 7 * 7, 500, dtype=torch.float32)
-        self.en4 = nn.Linear(500, z_dim, dtype=torch.float32)
+        self.en2 = nn.Conv2d(20, 50, kernel_size=5, stride=2, padding=2)
+        self.en_act2 = nn.Flatten()
+        self.en3 = nn.Linear(50 * 7 * 7, 500)
+        self.en4 = nn.Linear(500, z_dim)
 
-        # Decoder
-        self.de1 = nn.Conv2d(1,20,kernel_size=5,stride=2,padding=2, dtype=torch.float32)
+        # Decoder layers
+        self.de1 = nn.Linear(z_dim, 500)
         self.de_act1 = nn.ReLU()
-        self.de2 = nn.Linear(500, 2450, dtype=torch.float32)
-        self.unflat = nn.Unflatten(1, (50, 7, 7))
-        self.de3 = nn.ConvTranspose2d(50, 20, kernel_size=5, stride=2, padding=2, output_padding=1, dtype=torch.float32)
-        self.de4 = nn.ConvTranspose2d(20, 1, kernel_size=5, stride=2, padding=2, output_padding=1, dtype=torch.float32)
+        self.de2 = nn.Linear(500, 2450)
+        self.de_unflatten = nn.Unflatten(1, (50, 7, 7))
+        self.de_conv1 = nn.ConvTranspose2d(
+            50, 20, kernel_size=5, stride=2, padding=2, output_padding=1
+        )
+        self.de_conv2 = nn.ConvTranspose2d(
+            20, 1, kernel_size=5, stride=2, padding=2, output_padding=1
+        )
         self.de_act2 = nn.ReLU()
 
-    def encode(self, x):
+        self.output_shape = None
+
+    def encoder(self, x):
         s1 = self.en1(x)
         s2 = self.en_act1(s1)
         s3 = self.en2(s2)
-        s4 = self.en_flat(s3)
+        s4 = self.en_act2(s3)
         s5 = self.en3(s4)
         s6 = self.en4(s5)
         return s6
 
-    def decode(self, z):
-        s7 = self.de1(z)
-        s8 = self.de_act1(s7)
-        s9 = self.de2(s8)
-        s10 = self.unflat(s9)
-        s11 = self.de3(s10)
-        s12 = self.de4(s11)
-        s13 = self.de_act2(s12)
-        return s13
+    def decoder(self, z):
+        d1 = self.de1(z)
+        d2 = self.de_act1(d1)
+        d3 = self.de2(d2)
+        d4 = self.de_unflatten(d3)
+        d5 = self.de_conv1(d4)
+        d6 = self.de_conv2(d5)
+        self.output_shape = d6.shape
+        return d6
 
     def forward(self, x):
-        z = self.encode(x)
-        out = self.decode(z)
-        return out
+        encoded = self.encoder(x)
+        decoded = self.decoder(encoded)
+        return decoded
 
     def get_final_layer_dims(self):
-        return list(self.decoder.children())[-1]
+        return 
 
     def set_final_layer_dims(self, conv_op_shape):
         self.conv_op_shape = conv_op_shape
+
+    def save_encoder(self, file_path):
+        # Create an instance of the encoder
+        encoder_instance = nn.Sequential(self.en1, self.en_act1, self.en2, self.en_act2, self.en3, self.en4)
+        torch.save(encoder_instance.state_dict(), file_path)
+
+    def save_decoder(self, file_path):
+        # Create an instance of the decoder
+        decoder_instance = nn.Sequential(self.de1, self.de_act1, self.de2, self.de_unflatten, self.de_conv1, self.de_conv2, self.de_act2)
+        torch.save(decoder_instance.state_dict(), file_path)


### PR DESCRIPTION
Made a new PJ model which is FPGA friendly (at least the encoder part). From what I understand, `nn.Unflatten()` and `nn.ConvTranspose2d` isn't supported by `hls4ml`, so if you have any ideas @PRAkTIKal24 how to fix this, please let me know. 

This PR only makes additions to the model file and adds an if statement to the encoder/decoder separate saving function in `data_processing.py`, so everything should work as before.