### PR TITLE
Adjust version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ readme = "README.md"
 baler = "baler.baler:main"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.11.10"
+python = ">=3.8"
 torch = ">=2.0.0, !=2.0.1"
 tqdm = "^4.64.1"
 matplotlib = "^3.6.2"
 scikit-learn = "^1.2.0"
 hls4ml = { version = "^0.7.1", optional = true }
 tensorflow = { version = "^2.12.0", optional = true }
-numpy = "1.23.5"
+numpy = "^1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"


### PR DESCRIPTION
Drop maximum Python version constraint
Make numpy constraint a minimum version instead of an exact version

This allows building on Fedora 40 and 41 that currently have:
 - python3 3.12.2
 - numpy 1.26.4