### PR TITLE
Fix missing trailing commas in models.py

### DIFF
--- a/baler/modules/models.py
+++ b/baler/modules/models.py
@@ -355,7 +355,7 @@ class Conv_AE(nn.Module):
             nn.ReLU(),
             # nn.BatchNorm1d(self.q_z_output_dim),
             nn.Linear(self.q_z_mid_dim, self.q_z_output_dim),
-            nn.ReLU()
+            nn.ReLU(),
             # nn.BatchNorm1d(42720)
         )
         # Conv Layers
@@ -613,7 +613,7 @@ class Conv_AE_GDN(nn.Module):
             nn.ReLU(),
             # nn.BatchNorm1d(self.q_z_output_dim),
             nn.Linear(self.q_z_mid_dim, self.q_z_output_dim),
-            nn.ReLU()
+            nn.ReLU(),
             # nn.BatchNorm1d(42720)
         )
         # Conv Layers


### PR DESCRIPTION
## Description
Add missing trailing commas to match black formatting standards.

## Changes Made
- Added missing trailing commas in Conv_AE and Conv_AE_GDN classes (lines 358 and 616)
- Ensures consistent code style with black formatter

## Why This Matters
- Follows Python best practices for multi-line collections
- Prevents git diff issues when adding new items to lists
- Matches project's black formatting standards (mentioned in CONTRIBUTING.md)

## Testing
- `black --check baler/modules/models.py` now passes
- No functional changes to the neural network code
- Existing tests should continue to pass