### PR TITLE
Make model initialization constructor aware

### DIFF
--- a/baler/baler.py
+++ b/baler/baler.py
@@ -17,7 +17,7 @@ import time
 from math import ceil
 
 import numpy as np
-
+import inspect
 from .modules import helper
 import gzip
 from .modules.profiling import pytorch_profile
@@ -80,7 +80,30 @@ def main():
             + " not recognised. Use baler --help to see available modes."
         )
 
+def init_model(model_class, config, n_features):
+    """
+    Initialize model safely by inspecting constructor signature.
+    Handles different parameter names used across Baler models.
+    """
+    sig = inspect.signature(model_class.__init__)
+    kwargs = {}
 
+    if "n_features" in sig.parameters:
+        kwargs["n_features"] = n_features
+
+    if "input_dim" in sig.parameters:
+        kwargs["input_dim"] = n_features
+
+    if "in_dim" in sig.parameters:
+        kwargs["in_dim"] = n_features
+
+    if "z_dim" in sig.parameters:
+        kwargs["z_dim"] = config.latent_space_size
+
+    if "latent_dim" in sig.parameters:
+        kwargs["latent_dim"] = config.latent_space_size
+
+    return model_class(**kwargs)
 def perform_training(output_path, config, verbose: bool):
     """Main function calling the training functions, ran when --mode=train is selected.
         The three functions called are: `helper.process`, `helper.mode_init` and `helper.training`.
@@ -156,7 +179,12 @@ def perform_training(output_path, config, verbose: bool):
         print(f"Device used for training: {device}")
 
     model_object = helper.model_init(config.model_name)
-    model = model_object(n_features=n_features, z_dim=config.latent_space_size)
+    model = init_model(
+    model_object,
+    config=config,
+    n_features=n_features,
+)
+
     model.to(device)
 
     if config.model_name == "Conv_AE_3D" and hasattr(

--- a/baler/baler.py
+++ b/baler/baler.py
@@ -80,6 +80,7 @@ def main():
             + " not recognised. Use baler --help to see available modes."
         )
 
+
 def init_model(model_class, config, n_features):
     """
     Initialize model safely by inspecting constructor signature.
@@ -104,6 +105,8 @@ def init_model(model_class, config, n_features):
         kwargs["latent_dim"] = config.latent_space_size
 
     return model_class(**kwargs)
+
+
 def perform_training(output_path, config, verbose: bool):
     """Main function calling the training functions, ran when --mode=train is selected.
         The three functions called are: `helper.process`, `helper.mode_init` and `helper.training`.
@@ -180,10 +183,10 @@ def perform_training(output_path, config, verbose: bool):
 
     model_object = helper.model_init(config.model_name)
     model = init_model(
-    model_object,
-    config=config,
-    n_features=n_features,
-)
+        model_object,
+        config=config,
+        n_features=n_features,
+    )
 
     model.to(device)
 


### PR DESCRIPTION
Fix model initialization by making it constructor-aware instead of assuming
(n_features, z_dim) for all models.

Fixes issue #391

