### PR TITLE
Fix FTBFS with PyTorch >= 2.4

### DIFF
--- a/baler/modules/utils.py
+++ b/baler/modules/utils.py
@@ -316,7 +316,6 @@ class LRScheduler:
             patience=self.patience,
             factor=self.factor,
             min_lr=self.min_lr,
-            verbose=True,
         )
 
     def __call__(self, train_loss):


### PR DESCRIPTION
This patch was submitted to the Debian Bug Tracking System.
Author: Azeez Syed <azeezalishah@gmail.com>
The author's description of the patch follows:

Fix FTBFS with PyTorch >= 2.4: remove deprecated verbose argument PyTorch 2.4 removed the 'verbose' keyword argument from torch.optim.lr_scheduler.ReduceLROnPlateau.__init__() (deprecated since 2.2, removed in 2.4). Passing verbose=True now raises:

  TypeError: ReduceLROnPlateau.__init__() got an unexpected keyword argument 'verbose'

Removing the argument restores the original behaviour; LR change events are no longer logged to stdout by the scheduler, which is the upstream default.